### PR TITLE
lines => each_line

### DIFF
--- a/bin/create_yaggo_one_file
+++ b/bin/create_yaggo_one_file
@@ -1,7 +1,7 @@
 #! /usr/bin/env ruby
 
 def inline_includes ifd, ofd, loaded
-  ifd.lines.each { |l|
+  ifd.each_line { |l|
     if l =~ /^\s*require\s+['"]yaggo\/(\w+)['"]\s*$/
       file = $1
       unless loaded[file]


### PR DESCRIPTION
Although it isn't an issue for guix, I noticed that in the file https://github.com/gmarcais/yaggo/blob/master/bin/create_yaggo_one_file#L4 there is currently a deprecation issue, easily resolved by changing `lines` to `each_line`

before:
```
$ ruby bin/create_yaggo_one_file
bin/create_yaggo_one_file:4: warning: IO#lines is deprecated; use #each_line instead
bin/create_yaggo_one_file:4: warning: IO#lines is deprecated; use #each_line instead
bin/create_yaggo_one_file:4: warning: IO#lines is deprecated; use #each_line instead
bin/create_yaggo_one_file:4: warning: IO#lines is deprecated; use #each_line instead
bin/create_yaggo_one_file:4: warning: IO#lines is deprecated; use #each_line instead
bin/create_yaggo_one_file:4: warning: IO#lines is deprecated; use #each_line instead
bin/create_yaggo_one_file:4: warning: IO#lines is deprecated; use #each_line instead
bin/create_yaggo_one_file:4: warning: IO#lines is deprecated; use #each_line instead
bin/create_yaggo_one_file:4: warning: IO#lines is deprecated; use #each_line instead
$ ruby --version
ruby 2.1.2p95 (2014-05-08) [x86_64-linux-gnu]
```

However, I'm not sure what this script does so cannot test the fix, I just noticed a straightforward fix.

Thanks,
ben