### PR TITLE
Propagate user flags in the test makefile

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -1,12 +1,13 @@
-CC = g++
-CPPFLAGS = -I. -Wall -Werror
-CXXFLAGS = -O2
+CXX = g++
+CPPFLAGS += -I. -Wall -Werror
+CXXFLAGS += -O2
 YAGGO = ../bin/yaggo
 RY = ruby -I../lib $(YAGGO)
 
 all: count
 
 count: count.o
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o $@ $< $(LDFLAGS)
 count_cmdline.hpp _count: count_cmdline.yaggo $(YAGGO)
 	$(RY) --debug --zc _count $<
 count.o: count.cpp count_cmdline.hpp


### PR DESCRIPTION
Debian passes additional flags to harden builds
